### PR TITLE
Fix web worker self typing and comlink wrap missing generic  

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ import { expose } from 'comlink';
 export default {} as typeof Worker & { new (): Worker };
 
 // Define API
-const api = {
+export const api = {
   createMessage: (name: string): string => {
     return `Hello ${name}!`;
   },
@@ -150,11 +150,11 @@ Then, from within you main thread, wrap the instantiated worker and use the work
 
 ```ts
 import { wrap } from 'comlink';
-import MyComlinkWorker from './MyComlinkWorker.worker';
+import MyComlinkWorker, { api } from './MyComlinkWorker.worker';
 
 // Instantiate worker
 const myComlinkWorkerInstance: Worker = new MyComlinkWorker();
-const myComlinkWorkerApi = wrap(myComlinkWorkerInstance);
+const myComlinkWorkerApi = wrap<typeof api>(myComlinkWorkerInstance);
 
 // Call function in worker
 myComlinkWorkerApi.createMessage('John Doe').then((message: string) => {

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Now you can start using Web Workers! Two things are important here: Files that c
 must start with the following two lines of code in order to work nicely together with TypeScript:
 
 ```ts
-declare const self: Worker;
+declare const self: DedicatedWorkerGlobalScope;
 export default {} as typeof Worker & { new (): Worker };
 
 // Your code ...


### PR DESCRIPTION
- To access self properties, like `self.location` with the original `declare const self: Worker;` it will result in `Failed to compile.`
- comlink wrap without generic will result in `Failed to compile.`, too.

My testing versions:
```
node: v16.13.0
nvm: 0.38.0
typescript: "4.0.5"
    "react-app-rewired": "^2.1.8",
    "worker-loader": "^3.0.8"
    "react-scripts": "4.0.3",
```